### PR TITLE
Ensure 401 status on jwt expiry for hab admin and hostel routes

### DIFF
--- a/server/v1/middleware/authenticateJWT.js
+++ b/server/v1/middleware/authenticateJWT.js
@@ -85,6 +85,10 @@ const authenticateUserOrAdminJWT = async (req, res, next) => {
 
     return next(new AppError(403, "Not Authenticated"));
   } catch (err) {
+    if (err.name === "TokenExpiredError") {
+      return next(new AppError(401, "Access token expired"));
+    }
+
     console.error("Error verifying token:", err);
     return next(new AppError(500, "Server error during authentication"));
   }
@@ -112,6 +116,10 @@ const authenticateHabJWT = async (req, res, next) => {
     req.hab = decoded;
     return next();
   } catch (err) {
+    if (err.name === "TokenExpiredError") {
+      return next(new AppError(401, "Access token expired"));
+    }
+
     console.error("Error verifying HAB token:", err);
     return next(new AppError(403, "Not Authenticated"));
   }
@@ -142,6 +150,10 @@ const authenticateMessManagerJWT = async (req, res, next) => {
     req.managerHostel = hostel;
     return next();
   } catch (err) {
+    if (err.name === "TokenExpiredError") {
+      return next(new AppError(401, "Access token expired"));
+    }
+
     console.error("Error verifying Mess Manager token:", err);
     return next(new AppError(500, "Server error during authentication"));
   }

--- a/server/v1/modules/hostel/hostelModel.js
+++ b/server/v1/modules/hostel/hostelModel.js
@@ -93,7 +93,7 @@ hostelSchema.statics.findByAccessToken = async function (token) {
     return fetchedHostel;
   } catch (error) {
     console.error("Error verifying token:", error);
-    return false;
+    throw error;
   }
 };
 


### PR DESCRIPTION
Ensure 401 status is returned on jwt token expiry on other routes.