### PR TITLE
Add logger-worker configuration to ecosystem file

### DIFF
--- a/server/ecosystem.config.cjs
+++ b/server/ecosystem.config.cjs
@@ -48,5 +48,14 @@ module.exports = {
       max_memory_restart: "1G",
       instance_var: "NODE_APP_INSTANCE",
     },
+    {
+      name: "logger-worker",
+      script: "./loggerworker.js",
+      cwd: "./v2/workers",
+      instances: 1,
+      exec_mode: "fork",
+      watch: false,
+      autorestart: true,
+    }
   ],
 };


### PR DESCRIPTION
The loggerworker.js was not starting everytime the server restarts , we were manually running it each time the pm2 process restarts, 
Fix: adding it to pm2 ecosystemconfig.cjs with a single instance should fix the problem

Make sure to pm2 restart after updating this file in server